### PR TITLE
Fix: Make images work again!

### DIFF
--- a/gulp-tasks/images.mjs
+++ b/gulp-tasks/images.mjs
@@ -1,30 +1,30 @@
-const {dest, src} = require('gulp');
-const imagemin = require('gulp-imagemin');
-const mozjpeg = require('imagemin-mozjpeg');
-const optipng = require('imagemin-optipng');
+import { dest, src } from 'gulp';
+import imagemin from 'gulp-imagemin';
+import mozjpeg from 'imagemin-mozjpeg';
+import optipng from 'imagemin-optipng';
 
 // Grabs all images, runs them through imagemin
 // and plops them in the dist folder
 const images = () => {
   // We have specific configs for jpeg and png files to try
   // to really pull down asset sizes
-  return src('./src/images/**/*', {encoding: false})
+  return src('./src/images/**/*', { encoding: false })
     .pipe(
       imagemin(
         [
-          mozjpeg({quality: 60, progressive: true}),
-          optipng({optimizationLevel: 5, interlaced: null})
+          mozjpeg({ quality: 60, progressive: true }),
+          optipng({ optimizationLevel: 5, interlaced: null }),
         ],
         {
-          silent: true
+          silent: true,
         }
       )
     )
-    .on('error', function (err) { 
+    .on('error', function (err) {
       console.error('Image minification error:', err.message);
       this.emit('end');
     })
     .pipe(dest('./dist/images'));
 };
 
-module.exports = images;
+export default images;

--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -1,21 +1,21 @@
-const {parallel, watch} = require('gulp');
+import { parallel, watch } from 'gulp';
 
 // Pull in each task
-const images = require('./gulp-tasks/images.js');
-const sass = require('./gulp-tasks/sass.js');
+import images from './gulp-tasks/images.mjs';
+import sass from './gulp-tasks/sass.js';
 
 // Set each directory and contents that we want to watch and
 // assign the relevant task. `ignoreInitial` set to true will
 // prevent the task being run when we run `gulp watch`, but it
 // will run when a file changes.
 const watcher = () => {
-  watch('./src/scss/**/*.scss', {ignoreInitial: true}, sass);
-  watch('./src/images/**/*', {ignoreInitial: true}, images);
+  watch('./src/scss/**/*.scss', { ignoreInitial: true }, sass);
+  watch('./src/images/**/*', { ignoreInitial: true }, images);
 };
 
 // The default (if someone just runs `gulp`) is to run each task in parrallel
-exports.default = parallel(images, sass);
+export default parallel(images, sass);
 
 // This is our watcher task that instructs gulp to watch directories and
 // act accordingly
-exports.watch = watcher;
+export { watcher as watch };

--- a/src/index.md
+++ b/src/index.md
@@ -5,7 +5,7 @@ layout: 'layouts/home.html'
 
 banner:
   text: 'New:'
-  urltext: 'Images not appearing? I am working on a fix!'
+  urltext: 'Impactful Community Leader Award'
   url: 'https://blog.duncangeere.com/impactful-community-leader/'
 
 intro:


### PR DESCRIPTION
The JS ecosystem is a mess. Tried multiple different solutions, but eleventy and gulp clashed and crashed in most of them. 

Finally, i found [this post](https://stackoverflow.com/questions/73915537/eleventy-gulp-and-modules) that led me in the right direction. The solution was to use `.mjs` for the image related parts of gulp (that require ESM imports), so that eleventy could keep on using CJS require. 😵‍💫

Anyways, it should work now. 

PS. i took the liberty to update the banner on the frontpage to what it used to be as well, so it should all be ready for deployment!